### PR TITLE
Fix: Should not build matcaffe when there is no matlab

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -28,5 +28,6 @@
   shell: make matcaffe
   args:
     chdir: "{{ caffe_root }}"
+  when: not caffe_matlab_dir is none
   tags:
     - install


### PR DESCRIPTION
Fix: #1 